### PR TITLE
[Task rewrite] Take T: Copy + Into<NotifyHandle> in poll methods

### DIFF
--- a/src/stream/futures_unordered.rs
+++ b/src/stream/futures_unordered.rs
@@ -457,12 +457,13 @@ impl<T> Clone for MyInner<T> {
     }
 }
 
-impl<T> From<MyInner<T>> for NotifyHandle {
-    fn from(me: MyInner<T>) -> NotifyHandle {
+impl<'a, T> From<&'a MyInner<T>> for NotifyHandle {
+    fn from(me: &MyInner<T>) -> NotifyHandle {
         unsafe {
-            let handle = NotifyHandle::new(hide_lt(me.0));
-            mem::forget(me);
-            return handle
+            let clone = me.clone();
+            let handle = NotifyHandle::new(hide_lt(clone.0));
+            mem::forget(clone);
+            handle
         }
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -79,7 +79,7 @@ pub fn notify_panic() -> NotifyHandle {
         }
     }
 
-    NotifyHandle::from(Arc::new(Foo))
+    NotifyHandle::from(&Arc::new(Foo))
 }
 
 pub fn notify_noop() -> NotifyHandle {
@@ -89,7 +89,7 @@ pub fn notify_noop() -> NotifyHandle {
         fn notify(&self, _id: u64) {}
     }
 
-    NotifyHandle::from(Arc::new(Foo))
+    NotifyHandle::from(&Arc::new(Foo))
 }
 
 pub trait ForgetExt {


### PR DESCRIPTION
This generalizes the API since references are copy, the motivation is that it would work nicely with the following impls we may want:
`impl Into<NotifyHandle> for &'static T where T : Notify`
`impl Into<NotifyHandle> for fn(u64)`
The second in particular would be problematic without this since function pointers are not `Clone` due to a rustc bug.

ping @alexcrichton