### PR TITLE
Speed up no-std support when using std

### DIFF
--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -41,16 +41,8 @@ fn fresh_task_id() -> usize {
 fn set<'a, F, R>(task: &BorrowedTask<'a>, f: F) -> R
     where F: FnOnce() -> R
 {
-    struct Reset(*mut u8);
-    impl Drop for Reset {
-        fn drop(&mut self) {
-            set_ptr(self.0);
-        }
-    }
+    with_ptr(task as *const BorrowedTask<'a> as *mut u8, f)
 
-    let _reset = Reset(get_ptr());
-    set_ptr(task as *const BorrowedTask<'a> as *mut u8);
-    f()
 }
 
 fn with<F: FnOnce(&BorrowedTask) -> R, R>(f: F) -> R {


### PR DESCRIPTION
The initial implementation of no-std introduced a performance regression when using std. This was caused by a few factors:

* Additional calls to TLS accessors.
* Addition of dynamic dispatch.
* Addition of atomic ops.
* Less inlining

Most of these additions have been removed, leaving a single relaxed atomic load in the `task::current()` path as well as limiting the `call_once` to when the task is entered vs. in all task functions.

The `call_once` is not needed in the `current` path as calling this function from outside of the task system results in a panic anyway.

Before this patch: 43,872 ns/iter (+/- 7,981)
After this patch: 27,456 ns/iter (+/- 7,060)

The benchmark used was:

```rust
#![feature(test)]

extern crate futures;
extern crate test;

use futures::*;
use futures::executor::{Notify, NotifyHandle};
use futures::task::Task;

use test::Bencher;

fn notify_noop() -> NotifyHandle {
    struct Noop;

    impl Notify for Noop {
        fn notify(&self, _id: u64) {}
    }

    const NOOP : &'static Noop = &Noop;

    NotifyHandle::from(NOOP)
}

#[bench]
fn task_init(b: &mut Bencher) {
    const NUM: u32 = 1_000;

    struct MyFuture {
        num: u32,
        task: Option<Task>,
    };

    impl Future for MyFuture {
        type Item = ();
        type Error = ();

        fn poll(&mut self) -> Poll<(), ()> {
            if self.num == NUM {
                Ok(Async::Ready(()))
            } else {
                self.num += 1;

                if let Some(ref t) = self.task {
                    if t.will_notify_current() {
                        t.notify();
                        return Ok(Async::NotReady);
                    }
                }

                let t = task::current();
                t.notify();
                self.task = Some(t);

                Ok(Async::NotReady)
            }
        }
    }

    let notify = notify_noop();

    let mut fut = executor::spawn(MyFuture {
        num: 0,
        task: None,
    });

    b.iter(|| {
        fut.get_mut().num = 0;

        while let Ok(Async::NotReady) = fut.poll_future_notify(&notify, 0) {
        }
    });
}
```

cc @alexcrichton